### PR TITLE
The `--sync` option is deprecated and slated for removal in the next …

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ commands. Currently, there are groups *notebooks*, *test* and *workflows*.
 3) To make sure no other dependencies are present in the environment, occasionally run
 
 ```
-poetry install --sync
+poetry install sync
 ```
 
 and to update to latest compatible versions occasionally run


### PR DESCRIPTION
…minor release after June 2025, use the `poetry sync` command instead.

Poetry has deprecated the `--sync` option, we now have to use `sync`